### PR TITLE
Add n8n-nodes-praisonai to AI, LLM & Voice Nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 63 | [n8n-nodes-useapi](https://www.npmjs.com/package/n8n-nodes-useapi) | Integrates multiple accounts for Midjourney, Riffusion, Mureka, Runway, MiniMax, InsightFaceSwap, Pi... | [@lvalics](https://github.com/lvalics) | 0.2.3 | 10,155 | 33 |
 | 72 | [n8n-nodes-vercel-ai-sdk-universal-temp](https://www.npmjs.com/package/n8n-nodes-vercel-ai-sdk-universal-temp) | Universal AI SDK integration for n8n nodes. | [@hypocrite](https://www.npmjs.com/~hypocrite) | 0.2.99 | 7,927 | 1 |
 | 95 | [n8n-nodes-github-copilot](https://www.npmjs.com/package/n8n-nodes-github-copilot) | Integrates GitHub Copilot with CLI, Chat API, and AI chat models including GPT-5, Claude, and Gemini... | [@hugodeco](https://github.com/hugodeco) | 3.38.26 | 5,474 | 3 |
+| 🆕 | [n8n-nodes-praisonai](https://www.npmjs.com/package/n8n-nodes-praisonai) | Run AI agents with PraisonAI - multi-agent orchestration framework for building and running AI agent workflows. | [@MervinPraison](https://github.com/MervinPraison) | 0.1.0 | - | 0 |
 
 
 ## 7. File & PDF Manipulation Nodes


### PR DESCRIPTION
## New Community Node: n8n-nodes-praisonai

### Description
Adding **n8n-nodes-praisonai** - a community node for running AI agents with PraisonAI.

### Node Details
- **Package**: [n8n-nodes-praisonai](https://www.npmjs.com/package/n8n-nodes-praisonai)
- **GitHub**: [MervinPraison/n8n-nodes-praisonai](https://github.com/MervinPraison/n8n-nodes-praisonai)
- **Category**: AI, LLM & Voice Nodes

### Features
- Run individual AI agents with custom queries
- Execute multi-agent workflows
- List available agents from PraisonAI server
- Supports OpenAI, Claude, Gemini, and other LLMs via LiteLLM

### Use Cases
- AI-powered research automation
- Multi-agent content pipelines (Researcher → Writer → Editor)
- Slack/Discord AI assistants
- Automated customer support

### Links
- [PraisonAI Documentation](https://docs.praison.ai)
- [Example Workflows](https://github.com/MervinPraison/n8n-nodes-praisonai/tree/main/examples)