### PR TITLE
Add n8n Install to Self-Hosted resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 ## Useful Resources
 
 ### n8n Self‑Hosted
+- [n8n Install](https://github.com/kossakovsky/n8n-install) - One-command deployment with 30 AI tools (Ollama, Open WebUI, Supabase, Qdrant, etc.), auto HTTPS, and 300+ workflows
 - [Installing community nodes](https://docs.n8n.io/integrations/community-nodes/installation/)
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)


### PR DESCRIPTION
Adds n8n Install to the Self-Hosted section.

Docker Compose template that bundles n8n with 30 AI services (Ollama, Open WebUI, Supabase, Qdrant, etc.) and handles HTTPS automatically via Caddy.

**Key features:**
- Single command deployment of n8n + 30 optional services
- Interactive wizard for selecting which services to enable
- Automatic HTTPS via Caddy reverse proxy
- Queue mode with scalable workers for high-load workflows
- 300+ community workflows ready to import

622 stars, 171 forks, active development.