### PR TITLE
Add n8n-nodes-lemonsqueezy (Lemon Squeezy integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 96 | [n8n-nodes-chatwork](https://www.npmjs.com/package/n8n-nodes-chatwork) | Retrieves data from Chatwork API. | [@hoangdv](https://github.com/hoangdv) | 1.2.0 | 16,856 | 40 |
 | 99 | [n8n-nodes-qdrant](https://www.npmjs.com/package/n8n-nodes-qdrant) | Connects to Qdrant vector search engine. | [@qdrant-tech](https://github.com/qdrant-tech) | 0.2.1 | 14,235 | 7 |
 | 100 | [n8n-nodes-qdrant](https://www.npmjs.com/package/n8n-nodes-qdrant) | Connects to Qdrant vector search engine. | [@qdrant-tech](https://github.com/qdrant-tech) | 0.2.1 | 14,235 | 7 |
+| - | [n8n-nodes-lemonsqueezy](https://www.npmjs.com/package/n8n-nodes-lemonsqueezy) | Lemon Squeezy integration for digital products, subscriptions & license keys | [@janmaaarc](https://github.com/janmaaarc) | 0.5.0 | - | - |
 
 
 ## 6. AI, LLM & Voice Nodes


### PR DESCRIPTION
## Add Lemon Squeezy Community Node

Adding my community node for [Lemon Squeezy](https://lemonsqueezy.com) - a platform for selling digital products, subscriptions, and software licenses.

### Package Info
- **npm:** https://www.npmjs.com/package/n8n-nodes-lemonsqueezy
- **GitHub:** https://github.com/janmaaarc/n8n-nodes-lemonsqueezy
- **Category:** API & Cloud Integrations Nodes

### Features
- 15+ resources (Orders, Subscriptions, License Keys, Checkouts, Customers, Webhooks, etc.)
- Webhook trigger with mandatory signature verification
- License key validation/activation/deactivation
- Dynamic checkout link generation
- 87%+ test coverage
- Full TypeScript support

### Checklist
- [x] Package published on npm
- [x] Has `n8n-community-node-package` keyword
- [x] Working and tested