### PR TITLE
Add Taskade MCP Server to Compatible MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,8 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+
+### Compatible MCP Servers
+The [n8n-nodes-mcp](https://www.npmjs.com/package/n8n-nodes-mcp) community node (#4 above) lets n8n connect to any MCP-compatible server via SSE. Below are popular MCP servers that work with n8n:
+
+- [Taskade MCP Server](https://github.com/taskade/mcp) – 62+ tools for project management, tasks, docs, and AI agents. Connect via SSE endpoint (`npx @taskade/mcp-server --http --token YOUR_KEY`).


### PR DESCRIPTION
## Summary

Adds a **Compatible MCP Servers** subsection under Useful Resources, featuring [Taskade MCP Server](https://github.com/taskade/mcp).

Since [n8n-nodes-mcp](https://www.npmjs.com/package/n8n-nodes-mcp) is already ranked #4 in this list with 765K+ monthly downloads, it makes sense to highlight popular MCP servers that work with it. Taskade MCP Server provides 62+ tools for project management, tasks, docs, and AI agents, and connects to n8n via its SSE endpoint.

- **npm**: [@taskade/mcp-server](https://www.npmjs.com/package/@taskade/mcp-server)
- **GitHub**: https://github.com/taskade/mcp