### PR TITLE
Add @gre4ixin/n8n-nodes-appstore-connect (Apple App Store Connect integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 94 | [n8n-nodes-asaas-v2](https://www.npmjs.com/package/n8n-nodes-asaas-v2) | Integrates with the Asaas API. | [@degoisrs](https://github.com/degoisrs) | 1.0.15 | 3,986 | 43 |
 | 97 | [n8n-nodes-confirm8 🆕](https://www.npmjs.com/package/n8n-nodes-confirm8) | Integrates with Confirm8 API without requiring credentials. | [@billhebert](https://www.npmjs.com/~billhebert) | 0.52.0 | 3,873 | 5 |
 | 99 | [n8n-nodes-metricool-or 🆕](https://www.npmjs.com/package/n8n-nodes-metricool-or) | Integration with Metricool social media management platform. | [@kukis2107](https://github.com/kukis2107) | 1.3.1 | 3,647 | 3 |
+| - | [@gre4ixin/n8n-nodes-appstore-connect 🆕](https://www.npmjs.com/package/@gre4ixin/n8n-nodes-appstore-connect) | Apple App Store Connect API integration for managing apps, TestFlight, reviews, and sales reports. | [@gre4ixin](https://github.com/gre4ixin) | 1.0.1 | - | - |
 
 
 ## 6. AI, LLM & Voice Nodes


### PR DESCRIPTION
## Add Apple App Store Connect Community Node

Adding a community node for [Apple App Store Connect](https://appstoreconnect.apple.com) — the platform for managing iOS/macOS apps on the App Store.

### Package Info
- **npm:** https://www.npmjs.com/package/@gre4ixin/n8n-nodes-appstore-connect
- **GitHub:** https://github.com/gre4ixin/n8n-nodes-appstore-connect
- **Category:** API & Cloud Integrations Nodes

### Features
- App management (list apps, versions, build info)
- TestFlight (beta groups, beta testers, builds)
- Customer reviews & review responses
- Sales & finance reports (gzip-decompressed TSV)
- JWT authentication with ES256 (App Store Connect API standard)
- Pagination support with "Return All" option

### Checklist
- [x] Package published on npm
- [x] Has `n8n-community-node-package` keyword
- [x] Working and tested