### PR TITLE
Add n8n-starter to Self-Hosted resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 ## Useful Resources
 
 ### n8n Self‑Hosted
+- [n8n-starter](https://github.com/gabry-ts/n8n-starter) - GitOps for n8n. Version workflows in Git, two-way sync, AI agent integration, Docker Compose ready.
 - [Installing community nodes](https://docs.n8n.io/integrations/community-nodes/installation/)
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)


### PR DESCRIPTION
Adds [n8n-starter](https://github.com/gabry-ts/n8n-starter) to the Useful Resources > n8n Self-Hosted section.

**n8n-starter** is a GitOps setup for n8n:

- Every workflow and credential is a versioned file in Git
- Two-way sync: save in the n8n UI and it auto-exports to disk
- AI agents can create workflows by writing JSON files to the repo
- Docker Compose ready with workers, Postgres, Redis
- Production and dev modes included