### PR TITLE
Add n8n-nodes-sardis - AI agent payment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 94 | [n8n-nodes-asaas-v2](https://www.npmjs.com/package/n8n-nodes-asaas-v2) | Integrates with the Asaas API. | [@degoisrs](https://github.com/degoisrs) | 1.0.15 | 3,986 | 43 |
 | 97 | [n8n-nodes-confirm8 🆕](https://www.npmjs.com/package/n8n-nodes-confirm8) | Integrates with Confirm8 API without requiring credentials. | [@billhebert](https://www.npmjs.com/~billhebert) | 0.52.0 | 3,873 | 5 |
 | 99 | [n8n-nodes-metricool-or 🆕](https://www.npmjs.com/package/n8n-nodes-metricool-or) | Integration with Metricool social media management platform. | [@kukis2107](https://github.com/kukis2107) | 1.3.1 | 3,647 | 3 |
+| - | [n8n-nodes-sardis](https://www.npmjs.com/package/n8n-nodes-sardis) | Policy-controlled payments for AI agents via Sardis MPC wallets. | [@EfeDurmaz16](https://github.com/EfeDurmaz16) | 0.1.0 | - | 0 |
 
 
 ## 6. AI, LLM & Voice Nodes


### PR DESCRIPTION
Adds [n8n-nodes-sardis](https://www.npmjs.com/package/n8n-nodes-sardis) to the community nodes list.

Sardis enables AI agents and n8n workflows to make real financial transactions (USDC/USDT) with policy guardrails through non-custodial MPC wallets. Supports Base, Polygon, Ethereum, Arbitrum, and Optimism.

**Features:**
- Execute payments with spending policy checks
- Check wallet balance and limits
- Pre-validate payments against policy
- Multi-chain stablecoin support

**Install:** `npm install n8n-nodes-sardis` in your n8n instance