### PR TITLE
Add n8n-nodes-refgrow to API & Cloud Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 94 | [n8n-nodes-asaas-v2](https://www.npmjs.com/package/n8n-nodes-asaas-v2) | Integrates with the Asaas API. | [@degoisrs](https://github.com/degoisrs) | 1.0.15 | 3,986 | 43 |
 | 97 | [n8n-nodes-confirm8 🆕](https://www.npmjs.com/package/n8n-nodes-confirm8) | Integrates with Confirm8 API without requiring credentials. | [@billhebert](https://www.npmjs.com/~billhebert) | 0.52.0 | 3,873 | 5 |
 | 99 | [n8n-nodes-metricool-or 🆕](https://www.npmjs.com/package/n8n-nodes-metricool-or) | Integration with Metricool social media management platform. | [@kukis2107](https://github.com/kukis2107) | 1.3.1 | 3,647 | 3 |
+| - | [n8n-nodes-refgrow 🆕](https://www.npmjs.com/package/n8n-nodes-refgrow) | Affiliate and referral tracking for SaaS & AI products. Manage affiliates, conversions, referrals, and coupons. | [@alexandr-belogubov](https://github.com/alexandr-belogubov) | 0.1.0 | 0 | 0 |
 
 
 ## 6. AI, LLM & Voice Nodes


### PR DESCRIPTION
Adds [n8n-nodes-refgrow](https://www.npmjs.com/package/n8n-nodes-refgrow) — a community node for Refgrow affiliate tracking platform.

**What it does:**
- Manage affiliates, conversions, referrals, and coupons via Refgrow API
- Webhook triggers for 7 event types (new affiliate, new conversion, etc.)
- API key authentication

**Links:**
- npm: https://www.npmjs.com/package/n8n-nodes-refgrow
- GitHub: https://github.com/alexandr-belogubov/n8n-nodes-refgrow
- Website: https://refgrow.com