### PR TITLE
Add BulkPublish n8n community node

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 94 | [n8n-nodes-asaas-v2](https://www.npmjs.com/package/n8n-nodes-asaas-v2) | Integrates with the Asaas API. | [@degoisrs](https://github.com/degoisrs) | 1.0.15 | 3,986 | 43 |
 | 97 | [n8n-nodes-confirm8 🆕](https://www.npmjs.com/package/n8n-nodes-confirm8) | Integrates with Confirm8 API without requiring credentials. | [@billhebert](https://www.npmjs.com/~billhebert) | 0.52.0 | 3,873 | 5 |
 | 99 | [n8n-nodes-metricool-or 🆕](https://www.npmjs.com/package/n8n-nodes-metricool-or) | Integration with Metricool social media management platform. | [@kukis2107](https://github.com/kukis2107) | 1.3.1 | 3,647 | 3 |
+| - | [n8n-nodes-bulkpublish](https://www.npmjs.com/package/n8n-nodes-bulkpublish) | Publish and schedule content to 11 social media platforms via BulkPublish API. | [@azeemkafridi](https://github.com/azeemkafridi) | 1.0.0 | - | 1 |
 
 
 ## 6. AI, LLM & Voice Nodes


### PR DESCRIPTION
## Summary

Adds [n8n-nodes-bulkpublish](https://www.npmjs.com/package/n8n-nodes-bulkpublish) to the **API & Cloud Integrations Nodes** section.

BulkPublish is a social media publishing API that supports 11 platforms (Facebook, Instagram, X/Twitter, LinkedIn, TikTok, YouTube, Pinterest, Threads, Bluesky, Mastodon, Tumblr). The n8n community node lets you publish, schedule, and manage content across all platforms from n8n workflows.

- **npm**: `n8n-nodes-bulkpublish`
- **Website**: https://www.bulkpublish.com
- **GitHub**: https://github.com/azeemkafridi/bulkpublish-api