### PR TITLE
Add production n8n webhook security patterns to Useful Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [n8n Webhook Security — Production Patterns](https://github.com/veyis/pxlpeak-public-resources/blob/main/n8n-webhook-security.md) — 8-layer pattern: signed headers, shared secrets, IP allowlisting, rate limiting, payload validation, idempotency, safe error handling, secrets management.


### PR DESCRIPTION
## What

Adds one entry to the **Useful Resources → n8n Self-Hosted** section:

> [n8n Webhook Security — Production Patterns](https://github.com/veyis/pxlpeak-public-resources/blob/main/n8n-webhook-security.md) — 8-layer pattern: signed headers, shared secrets, IP allowlisting, rate limiting, payload validation, idempotency, safe error handling, secrets management.

## Why

The existing self-hosted resources cover install + scraping + developer basics but nothing on production webhook hardening, which is the single most common production-n8n mistake I see in client work (e.g., duplicate orders from missing idempotency, leaked secrets via verbose error messages, unauthenticated public webhook endpoints).

The linked page is an open, no-signup, no-gate technical reference covering:

1. Signed-header verification (Shopify/Twilio/Stripe examples)
2. Shared-secret auth with `timingSafeEqual`
3. IP allowlisting at the proxy layer
4. Rate limiting per source
5. Payload shape validation
6. **Idempotency** with Redis `SETNX` or Postgres `ON CONFLICT`
7. Safe error handling (no internal-state leaks)
8. Secrets in env / vault, not workflow nodes

Code snippets are copy-pasteable into n8n Code nodes. Content is CC-like / free to adapt.

## Fit

- Matches existing blog-post-style entries in the section
- Not promoting an npm package or SaaS — pure reference content
- Aligned with the "useful n8n resources" spirit of the section

Happy to tweak the wording / placement / description length if it helps.