### PR TITLE
Add n8n-nodes-scala — S.C.A.L.A. AI OS (CRM + 244M company Score API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 | 94 | [n8n-nodes-asaas-v2](https://www.npmjs.com/package/n8n-nodes-asaas-v2) | Integrates with the Asaas API. | [@degoisrs](https://github.com/degoisrs) | 1.0.15 | 3,986 | 43 |
 | 97 | [n8n-nodes-confirm8 🆕](https://www.npmjs.com/package/n8n-nodes-confirm8) | Integrates with Confirm8 API without requiring credentials. | [@billhebert](https://www.npmjs.com/~billhebert) | 0.52.0 | 3,873 | 5 |
 | 99 | [n8n-nodes-metricool-or 🆕](https://www.npmjs.com/package/n8n-nodes-metricool-or) | Integration with Metricool social media management platform. | [@kukis2107](https://github.com/kukis2107) | 1.3.1 | 3,647 | 3 |
+| - | [n8n-nodes-scala 🆕](https://www.npmjs.com/package/n8n-nodes-scala) | S.C.A.L.A. AI OS integration — CRM, Score API (244M+ company records across 40+ countries), and workflow automation. | [@Alessandro114](https://github.com/Alessandro114) | 0.1.0 | 0 | 1 |
 
 
 ## 6. AI, LLM & Voice Nodes


### PR DESCRIPTION
Adds [n8n-nodes-scala](https://www.npmjs.com/package/n8n-nodes-scala) — a community node for [S.C.A.L.A. AI OS](https://get-scala.com), the enterprise AI operating system.

**What it does:**
- **Score API** — Search and enrich 244M+ companies across 40+ countries. Financial data, risk scores, NACE codes, revenue estimates.
- **CRM** — Full contact lifecycle: create, update, pipeline stages, kanban view, email, timeline.
- **Data Tables** — Generic CRUD on any S.C.A.L.A. table (contacts, tickets, assets, invoices, orders).
- **Webhooks** — Real-time event triggers: new contact, WhatsApp message, order created, and more.

**Links:**
- npm: https://www.npmjs.com/package/n8n-nodes-scala
- GitHub: https://github.com/Alessandro114/n8n-nodes-scala
- Website: https://get-scala.com

**Section:** API & Cloud Integrations Nodes (similar to Kommo CRM, CNPJ company lookup, etc.)