### PR TITLE
Add n8n-security to Useful Resources (n8n Self-Hosted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [n8n-security](https://github.com/Perufitlife/n8n-security) - One-line CLI auditor for self-hosted n8n: checks for unauthenticated `/rest/settings` exposure and CVE-2026-21858, no token required (`npx n8n-security --url https://your-n8n.example.com`)


### PR DESCRIPTION
Adds **n8n-security** to the `Useful Resources > n8n Self-Hosted` section — the manually-curated resources list (the node sections are crawler-generated, so this seemed like the right place).

`n8n-security` is an open-source (MIT, zero-dependency) one-line CLI that audits a self-hosted n8n instance for takeover-grade misconfigurations: the unauthenticated `/rest/settings` config+version leak, open owner-setup registration, a missing auth wall on the editor/REST API, and a running version exposed to **CVE-2026-21858 'Ni8mare'** (CVSS 10.0, unauth RCE) — confirming each live via an anonymous probe.

- Repo: https://github.com/Perufitlife/n8n-security
- Usage: `npx n8n-security --url https://your-n8n.example.com`

Disclosure: I am the author of this tool.