### PR TITLE
Add n8n Code node tutorial to Useful Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [n8n Code node tutorial: JavaScript & Python guide](https://stacksheriff.com/automation/n8n-code-node-tutorial/)


### PR DESCRIPTION
Adds a practical, in-depth guide to the n8n **Code node** (JavaScript & Python) under Useful Resources → n8n Self-Hosted, next to the other developer guides.

- **Guide:** https://stacksheriff.com/automation/n8n-code-node-tutorial/
- Covers running JS and Python in the Code node, item structure, common patterns, and pitfalls — a fit alongside the existing 'n8n for developers' entry.

Thanks for maintaining this list!