### PR TITLE
Add "Self-host n8n" guide to Useful Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [Self-host n8n: Docker vs one-click deploy](https://n8n.runonflux.com/self-host-n8n)


### PR DESCRIPTION
Adds a practical self-hosting guide to Useful Resources → n8n Self-Hosted: Docker setup vs a one-click deploy, covering ports, persistence and data ownership.

- Single link, matches the existing plain-link format
- On-topic self-hosting resource

Disclosure: I'm affiliated with the site.