### PR TITLE
Add self-hosting n8n with Docker guide to Useful Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [Self-hosting n8n free with Docker](https://lalittaparia.online/tutorials/how-to-use-n8n-for-free-with-docker) — one command to a running instance, plus the `localhost` vs container-hostname gotcha that breaks most first setups


### PR DESCRIPTION
Adds one link to the **n8n Self-Hosted** section.

It's a walkthrough of getting n8n running with Docker from scratch, and it covers the `localhost` vs container-hostname problem that breaks most first setups — when a node inside the container tries to reach a service on the host and silently fails.

Disclosure: this is my own site. Happy to drop it if it's not a fit for the list.