### PR TITLE
Add a self-hosting walkthrough under Useful Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [Self-hosting n8n with Docker Compose and Caddy](https://noderecipe.com/self-host-n8n)


### PR DESCRIPTION
Adds one line to **Useful Resources → n8n Self‑Hosted**:

`- [Self-hosting n8n with Docker Compose and Caddy](https://noderecipe.com/self-host-n8n)`

The section currently points at the two official docs pages and two write-ups. This adds a full walkthrough for the gap between them — getting a working instance on a VPS:

- Docker Compose file with Postgres, and why SQLite is the wrong default once you have Wait nodes or approval steps
- Caddy reverse proxy with automatic TLS, and the `WEBHOOK_URL` / `N8N_HOST` settings that webhooks need to resolve correctly
- Backups, upgrades, and the encryption-key trap that makes credentials unrecoverable if you lose it
- Written against n8n 2.x, including the Active → Publish rename

**Disclosure:** this is my own site. I've kept it to a single entry in the section it belongs to; happy to drop it if it isn't a fit for the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)