### PR TITLE
Add Portuguese-language n8n self-hosting guide to Useful Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,4 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+- [Instalar n8n em VPS Ubuntu (guia em português)](https://yousecure.io/blog/n8n-self-hosted-instalando-automacao-vps-ubuntu)


### PR DESCRIPTION
Adds one link to the "n8n Self-Hosted" resources section: a step-by-step guide to installing n8n on an Ubuntu VPS, written in Portuguese.

Everything currently listed is in English. Brazil is one of the larger n8n communities and there's very little self-hosting material in Portuguese, so this fills a gap rather than duplicating an existing entry.

Disclosure: it's on my company's blog. Happy to drop it if you'd rather keep the section vendor-neutral.