### PR TITLE
Add n8n-qdrant-fastapi-bridge vector database integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,6 @@ ScrapeNinja handles headless browsers, proxies, timeouts, retries, and helps wit
 - [Installing and updating n8n in Docker](https://docs.n8n.io/hosting/installation/docker/)
 - [Web scraping in n8n](https://pixeljets.com/blog/web-scraping-in-n8n/)
 - [n8n for developers](https://pixeljets.com/blog/n8n/)
+
+
+- [n8n-qdrant-fastapi-bridge](https://github.com/AlfazMahmudRizve/n8n-qdrant-fastapi-bridge) - Production-ready FastAPI bridge connecting n8n workflows to self-hosted Qdrant vector database with bearer token security and sub-5ms local embeddings.


### PR DESCRIPTION
### Description
Adds [n8n-qdrant-fastapi-bridge](https://github.com/AlfazMahmudRizve/n8n-qdrant-fastapi-bridge) to the list of community n8n integrations.

### Features
- Connects n8n AI agent nodes to self-hosted Qdrant vector databases
- FastEmbed sub-5ms local ONNX embeddings (no OpenAI API rate limits)
- Bearer token authentication and Docker Compose deployment

Thank you!